### PR TITLE
Feature/#6 cancel order

### DIFF
--- a/http/request.http
+++ b/http/request.http
@@ -1,53 +1,53 @@
-### 1) 전체 주문 조회
-GET http://localhost:8080/orders
+### 0) 전체 주문 조회 (ID 확인용)
+GET http://localhost:10345/orders
 Accept: application/json
 
 ###
 
-### 2) 주문 생성: 배송일자 미지정 → 기본 오늘
-POST http://localhost:8080/orders
+### 1) 주문 생성
+POST http://localhost:10345/orders
 Content-Type: application/json
 
 {
   "orderType": "guest",
-  "guestName": "홍길동",
-  "guestPhone": "010-1234-5678",
+  "guestName": "테스트",
+  "guestPhone": "010-0000-0000",
   "items": [
-    {
-      "bookId": 1,
-      "quantity": 2,
-      "giftWrapped": false
-    }
+    { "bookId": 1, "quantity": 1, "giftWrapped": false }
   ]
+}
+
+> {%
+    // response.body가 문자열인지 객체인지 판별
+    let body = response.body;
+    if (typeof body === 'string') {
+        body = JSON.parse(body);
+    }
+    client.global.set("orderId", body.orderId);
+%}
+
+###
+
+### 2) 주문 취소: 정상 (생성된 PENDING 주문)
+POST http://localhost:10345/orders/{{orderId}}/cancel
+Content-Type: application/json
+
+{
+  "reason": "고객 요청"
 }
 
 ###
 
-### 3) 주문 생성: 배송일자 지정 (예: 2025-06-15)
-POST http://localhost:8080/orders
-Content-Type: application/json
-
-{
-  "orderType": "member",
-  "userId": 42,
-  "deliveryDate": "2025-06-15",
-  "items": [
-    {
-      "bookId": 2,
-      "quantity": 1,
-      "giftWrapped": true,
-      "wrappingId": 5
-    }
-  ]
-}
+### 3) 이미 취소된 주문 재요청
+POST http://localhost:10345/orders/{{orderId}}/cancel
 
 ###
 
-### 4) 오류 예시: member인데 userId 누락
-POST http://localhost:8080/orders
-Content-Type: application/json
+### 4) 배송 중(또는 완료) 상태 주문 취소 시도
+# SHIPPING 상태로 변경된 주문 ID를 직접 지정
+POST http://localhost:10345/orders/2/cancel
 
-{
-  "orderType": "member",
-  "items": []
-}
+###
+
+### 5) 존재하지 않는 주문 ID
+POST http://localhost:10345/orders/999/cancel

--- a/src/main/java/com/nhnacademy/bookstoreorderapi/order/controller/OrderController.java
+++ b/src/main/java/com/nhnacademy/bookstoreorderapi/order/controller/OrderController.java
@@ -7,6 +7,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import com.nhnacademy.bookstoreorderapi.order.domain.exception.ResourceNotFoundException;  
+import java.util.Map;                                                           
 
 import java.util.List;
 

--- a/src/main/java/com/nhnacademy/bookstoreorderapi/order/controller/OrderController.java
+++ b/src/main/java/com/nhnacademy/bookstoreorderapi/order/controller/OrderController.java
@@ -1,5 +1,7 @@
 package com.nhnacademy.bookstoreorderapi.order.controller;
 
+import com.nhnacademy.bookstoreorderapi.order.domain.exception.ResourceNotFoundException;
+import com.nhnacademy.bookstoreorderapi.order.dto.CancelOrderRequestDto;
 import com.nhnacademy.bookstoreorderapi.order.dto.OrderRequestDto;
 import com.nhnacademy.bookstoreorderapi.order.dto.OrderResponseDto;
 import com.nhnacademy.bookstoreorderapi.order.dto.StatusChangeDto;
@@ -55,6 +57,19 @@ public class OrderController {
             }
         } else {
             throw new IllegalArgumentException("orderType은 'member' 또는 'guest'여야 합니다.");
+        }
+    }
+    @PostMapping("/{orderId}/cancel")
+    public ResponseEntity<?> cancelOrder(
+            @PathVariable Long orderId,
+            @RequestBody(required = false) CancelOrderRequestDto dto
+    ) {
+        String reason = (dto != null ? dto.getReason() : null);
+        try {
+            orderService.cancelOrder(orderId, reason);
+            return ResponseEntity.ok().build();
+        } catch (IllegalStateException | ResourceNotFoundException e) {
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
         }
     }
 }

--- a/src/main/java/com/nhnacademy/bookstoreorderapi/order/domain/entity/CanceledOrder.java
+++ b/src/main/java/com/nhnacademy/bookstoreorderapi/order/domain/entity/CanceledOrder.java
@@ -1,0 +1,35 @@
+package com.nhnacademy.bookstoreorderapi.order.domain.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "canceled_order")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CanceledOrder {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long orderId;
+
+  //취소주문 시간
+    private LocalDateTime canceledAt;
+
+  //취소 주문 사유
+    private String reason;
+}

--- a/src/main/java/com/nhnacademy/bookstoreorderapi/order/dto/CancelOrderRequestDto.java
+++ b/src/main/java/com/nhnacademy/bookstoreorderapi/order/dto/CancelOrderRequestDto.java
@@ -1,0 +1,12 @@
+package com.nhnacademy.bookstoreorderapi.order.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CancelOrderRequestDto {
+    private String reason;
+}

--- a/src/main/java/com/nhnacademy/bookstoreorderapi/order/repository/CanceledOrderRepository.java
+++ b/src/main/java/com/nhnacademy/bookstoreorderapi/order/repository/CanceledOrderRepository.java
@@ -1,0 +1,7 @@
+package com.nhnacademy.bookstoreorderapi.order.repository;
+
+import com.nhnacademy.bookstoreorderapi.order.domain.entity.CanceledOrder;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CanceledOrderRepository extends JpaRepository<CanceledOrder, Long> {
+}

--- a/src/main/java/com/nhnacademy/bookstoreorderapi/order/service/OrderService.java
+++ b/src/main/java/com/nhnacademy/bookstoreorderapi/order/service/OrderService.java
@@ -19,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/src/main/java/com/nhnacademy/bookstoreorderapi/order/service/OrderService.java
+++ b/src/main/java/com/nhnacademy/bookstoreorderapi/order/service/OrderService.java
@@ -11,14 +11,13 @@ import com.nhnacademy.bookstoreorderapi.order.dto.OrderRequestDto;
 import com.nhnacademy.bookstoreorderapi.order.dto.OrderResponseDto;
 import com.nhnacademy.bookstoreorderapi.order.repository.OrderRepository;
 import com.nhnacademy.bookstoreorderapi.order.repository.WrappingRepository;
-improt com.nhnacademy.bookstoreorderapi.order.repository.CanceledOrderRepository;
+import com.nhnacademy.bookstoreorderapi.order.repository.CanceledOrderRepository;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/src/main/java/com/nhnacademy/bookstoreorderapi/order/service/OrderService.java
+++ b/src/main/java/com/nhnacademy/bookstoreorderapi/order/service/OrderService.java
@@ -11,6 +11,8 @@ import com.nhnacademy.bookstoreorderapi.order.dto.OrderRequestDto;
 import com.nhnacademy.bookstoreorderapi.order.dto.OrderResponseDto;
 import com.nhnacademy.bookstoreorderapi.order.repository.OrderRepository;
 import com.nhnacademy.bookstoreorderapi.order.repository.WrappingRepository;
+improt com.nhnacademy.bookstoreorderapi.order.repository.CanceledOrderRepository;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/nhnacademy/bookstoreorderapi/order/service/OrderService.java
+++ b/src/main/java/com/nhnacademy/bookstoreorderapi/order/service/OrderService.java
@@ -12,6 +12,7 @@ import com.nhnacademy.bookstoreorderapi.order.dto.OrderResponseDto;
 import com.nhnacademy.bookstoreorderapi.order.repository.OrderRepository;
 import com.nhnacademy.bookstoreorderapi.order.repository.WrappingRepository;
 import com.nhnacademy.bookstoreorderapi.order.repository.CanceledOrderRepository;
+import com.nhnacademy.bookstoreorderapi.order.domain.entity.CanceledOrder;        
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,4 @@
 spring.application.name=bookstore-order-api
-server.port=8080
+server.port=10345
 
 spring.profiles.active=dev

--- a/src/main/resources/data-dev.sql
+++ b/src/main/resources/data-dev.sql
@@ -1,3 +1,6 @@
 INSERT INTO wrapping(name, price, is_active) VALUES
                                                  ('기본 포장', 2000, TRUE),
                                                  ('선물 포장', 5000, TRUE);
+
+INSERT INTO orders (id, user_id, guest_name, guest_phone, status, requested_at, created_at, updated_at, delivery_at, total_price, delivery_fee, final_price)
+VALUES (1, NULL, '테스트', '010-0000-0000', 'PENDING', NOW(), NOW(), NOW(), NOW(), 10000, 3000, 13000);

--- a/src/test/java/com/nhnacademy/bookstoreorderapi/order/dto/CancelOrderRequestDtoTest.java
+++ b/src/test/java/com/nhnacademy/bookstoreorderapi/order/dto/CancelOrderRequestDtoTest.java
@@ -1,0 +1,26 @@
+// src/test/java/com/nhnacademy/bookstoreorderapi/order/dto/CancelOrderRequestDtoTest.java
+package com.nhnacademy.bookstoreorderapi.order.dto;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CancelOrderRequestDtoTest {
+
+    @Test
+    void builderSetsReasonCorrectly() {
+        CancelOrderRequestDto dto = CancelOrderRequestDto.builder()
+            .reason("고객 변심")
+            .build();
+
+        assertThat(dto.getReason()).isEqualTo("고객 변심");
+    }
+
+    @Test
+    void setterAndGetterWork() {
+        CancelOrderRequestDto dto = new CancelOrderRequestDto();
+        dto.setReason("재고 없음");
+
+        assertThat(dto.getReason()).isEqualTo("재고 없음");
+    }
+}

--- a/src/test/java/com/nhnacademy/bookstoreorderapi/order/service/OrderServiceCancelTest.java
+++ b/src/test/java/com/nhnacademy/bookstoreorderapi/order/service/OrderServiceCancelTest.java
@@ -1,0 +1,91 @@
+// src/test/java/com/nhnacademy/bookstoreorderapi/order/service/OrderServiceCancelTest.java
+package com.nhnacademy.bookstoreorderapi.order.service;
+
+import com.nhnacademy.bookstoreorderapi.order.domain.entity.CanceledOrder;
+import com.nhnacademy.bookstoreorderapi.order.domain.entity.Order;
+import com.nhnacademy.bookstoreorderapi.order.domain.entity.OrderStatus;
+import com.nhnacademy.bookstoreorderapi.order.repository.CanceledOrderRepository;
+import com.nhnacademy.bookstoreorderapi.order.repository.OrderRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OrderServiceCancelTest {
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Mock
+    private CanceledOrderRepository canceledOrderRepository;
+
+    @InjectMocks
+    private OrderService orderService;
+
+    private Order pendingOrder;
+    private Order shippedOrder;
+
+    @BeforeEach
+    void setUp() {
+        pendingOrder = Order.builder()
+                .id(1L)
+                .status(OrderStatus.PENDING)
+                .build();
+
+        shippedOrder = Order.builder()
+                .id(2L)
+                .status(OrderStatus.SHIPPING)
+                .build();
+    }
+
+    @Test
+    void cancelOrder_whenPending_savesCanceledRecordAndUpdatesStatus() {
+        // 준비
+        when(orderRepository.findById(1L)).thenReturn(Optional.of(pendingOrder));
+        ArgumentCaptor<CanceledOrder> captor = ArgumentCaptor.forClass(CanceledOrder.class);
+
+        // 실행
+        orderService.cancelOrder(1L, "고객 요청");
+
+        // 검증: 주문 상태 변경
+        assertThat(pendingOrder.getStatus()).isEqualTo(OrderStatus.CANCELED);
+        // 검증: 취소 기록 저장
+        verify(canceledOrderRepository).save(captor.capture());
+        CanceledOrder record = captor.getValue();
+        assertThat(record.getOrderId()).isEqualTo(1L);
+        assertThat(record.getReason()).isEqualTo("고객 요청");
+        assertThat(record.getCanceledAt()).isBeforeOrEqualTo(LocalDateTime.now());
+        // 검증: 주문 저장 호출
+        verify(orderRepository).save(pendingOrder);
+    }
+
+    @Test
+    void cancelOrder_whenNotPending_throwsException() {
+        // 준비: SHIPPING 상태인 주문
+        when(orderRepository.findById(2L)).thenReturn(Optional.of(shippedOrder));
+
+        // 실행 & 검증
+        assertThatThrownBy(() -> orderService.cancelOrder(2L, null))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("배송 전 주문만 취소 가능합니다.");
+        // 취소 기록 저장 안 함
+        verify(orderRepository, never()).save(any());
+    }
+
+    @Test
+    void cancelOrder_whenNotFound_throwsNotFound() {
+        when(orderRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> orderService.cancelOrder(99L, "테스트"))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("주문을 찾을 수 없습니다.");
+    }
+}


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📝 PR 개요

- 배송 전 주문 취소 기능 및 취소 기록 테이블(canceled_order) 연동을 위한 API와 서비스 로직을 추가했습니다.
- 주문 상태가 PENDING(결제 완료 직후)일 때만 취소 가능
- 취소 요청 시 사유를 입력받아 canceled_order 테이블에 취소 시각과 사유를 저장
- 주문 상태를 CANCELED로 변경

## 🔗 관련 이슈

- 관련된 이슈 번호 #18 

## ✅ 체크리스트

- [ ] 코드가 정상적으로 동작합니다.
- [ ] 새로운/수정된 기능에 대한 테스트를 추가했습니다.
- [ ] 문서(README 등)를 최신 상태로 반영했습니다.
- [ ] 코드 스타일 가이드 및 커밋 메시지 규칙을 준수했습니다.

## 🖼️ 변경 전/후 스크린샷 (UI 변경 시, 선택)

- 변경된 UI가 있다면 스크린샷을 첨부해 주세요.

## 💬 기타 참고 사항

- 리뷰어가 참고하면 좋을 추가 정보나 특이사항을 적어 주세요.
