### PR TITLE
Feature#89 payment(cancel) 3

### DIFF
--- a/src/main/java/com/nhnacademy/bookstoreorderapi/payment/service/impl/PaymentServiceImpl.java
+++ b/src/main/java/com/nhnacademy/bookstoreorderapi/payment/service/impl/PaymentServiceImpl.java
@@ -54,6 +54,7 @@ public class PaymentServiceImpl implements PaymentService {
                 .flatMap(Optional::stream)
                 .findFirst()
                 .orElseThrow(() -> new RedirectUrlNotFoundException(resp));
+
     }
 
     /** Toss 결제 요청 생성 */

--- a/src/main/java/com/nhnacademy/bookstoreorderapi/payment/service/impl/PaymentServiceImpl.java
+++ b/src/main/java/com/nhnacademy/bookstoreorderapi/payment/service/impl/PaymentServiceImpl.java
@@ -38,15 +38,18 @@ public class PaymentServiceImpl implements PaymentService {
     /** Map 응답에서 첫 번째 non-null URL을 꺼냅니다. */
     private String extractRedirectUrl(Map<String, Object> resp) {
         return Stream.of(
+                        Optional.ofNullable(resp.get("nextRedirectPcUrl")).map(Object::toString),
+                        Optional.ofNullable(resp.get("nextRedirectMobileUrl")).map(Object::toString),
+                        Optional.ofNullable(resp.get("hostedCheckoutUrl")).map(Object::toString),
+                        /* ↓ 이하 테스트·샌드박스 키 */
+                        Optional.ofNullable(resp.get("checkoutUrl")).map(Object::toString),
+                        Optional.ofNullable(resp.get("checkoutPageUrl")).map(Object::toString),
+                        Optional.ofNullable(resp.get("paymentUrl")).map(Object::toString),
                         Optional.ofNullable(resp.get("checkout"))
                                 .filter(Map.class::isInstance)
                                 .map(Map.class::cast)
                                 .map(m -> m.get("url"))
-                                .map(Object::toString),
-                        Optional.ofNullable(resp.get("checkoutUrl")).map(Object::toString),
-                        Optional.ofNullable(resp.get("checkoutPageUrl")).map(Object::toString),
-                        Optional.ofNullable(resp.get("paymentUrl")).map(Object::toString),
-                        Optional.ofNullable(resp.get("nextRedirectPcUrl")).map(Object::toString)
+                                .map(Object::toString)
                 )
                 .flatMap(Optional::stream)
                 .findFirst()


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📝 PR 개요

- **라이브 환경 결제 흐름 개선**
  - Toss 실결제 응답 필드(`nextRedirectPcUrl`, `nextRedirectMobileUrl`, `hostedCheckoutUrl`) 대응  
  - `extractRedirectUrl()` 로직 확장 → 결제창 URL 미탐지로 인한 302 `/` 리디렉션 문제 해결
- **환불 엔드포인트 통합**
  - `/v1/payments/{paymentKey}/cancel` 단일 엔드포인트 사용
  - 카드/가상계좌 구분 제거 → 404 Not Found 오류 해결
- **주문 상태 전이**
  - 결제 SUCCESS 시 `Order.status = PENDING` 저장

## 🔗 관련 이슈
#89 
- closes #123  
  `결제 버튼 클릭 시 메인으로 이동`  
- closes #124  
  `실서버 환불 요청 404 오류`

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작합니다. (로컬 + 실도메인 E2E 테스트)
- [ ] 문서(README, API 명세서) 최신화
- [x] 코드 스타일 가이드 및 커밋 메시지 규칙 준수

## 🖼️ 변경 전/후 스크린샷 (UI 변경 시, 선택)


## 💬 기타 참고 사항
