### PR TITLE
fix(config): 프로덕션 Toss success/fail URL을 게이트웨이 도메인으로 변경

### DIFF
--- a/src/main/java/com/nhnacademy/bookstoreorderapi/payment/config/TossPaymentConfig.java
+++ b/src/main/java/com/nhnacademy/bookstoreorderapi/payment/config/TossPaymentConfig.java
@@ -8,13 +8,7 @@ import org.springframework.context.annotation.Configuration;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
-/**
- * application.yml 의 payment.toss.* 설정을 바인딩
- * - baseUrl        : https://sandbox.tosspayments.com/v1  (샌드박스)
- * - clientApiKey   : test_ck_...
- * - secretApiKey   : test_sk_...
- * - successUrl, failUrl : 콜백 URL
- */
+
 @Configuration
 @ConfigurationProperties(prefix = "payment.toss")
 @Getter

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -29,8 +29,9 @@ resilience4j.circuitbreaker.configs.default.sliding-window-size=100
 payment.toss.base-url=https://api.tosspayments.com/v1
 payment.toss.client-api-key=test_ck_DLJOpm5QrlwNvJboZZaNVPNdxbWn
 payment.toss.secret-api-key=test_sk_Gv6LjeKD8a9512k9vamx8wYxAdXy
-payment.toss.success-url=http://s1.java21.net:10350/api/v1/payments/toss/success
-payment.toss.fail-url=http://s1.java21.net:10350/api/v1/payments/toss/fail
+payment.toss.success-url=https://bookstore-beansoild.store/api/v1/payments/toss/success
+payment.toss.fail-url=https://bookstore-beansoild.store/api/v1/payments/toss/fail
+
 
 # Management (Actuator) 설정
 management.endpoints.web.exposure.include=health,info,mappings


### PR DESCRIPTION
- application-prod.yml 에 success-url·fail-url 값을 https://bookstore-beansolid.store 로 교체

<!-- .github/pull_request_template.md -->

## 📝 PR 개요

프로덕션 환경에서 Toss 결제 콜백이 내부 포트(10350)로 향하던 문제를 해결하기 위해,
success/fail URL을 공개 도메인(bookstore-beansolid.store) 기준으로 수정했습니다.

## 🔗 관련 이슈

#96 
## ✅ 체크리스트

- [x] 코드가 정상적으로 동작합니다.
- [x] 새로운/수정된 기능에 대한 테스트를 추가했습니다.
- [ ] 문서(README 등)를 최신 상태로 반영했습니다.
- [x] 코드 스타일 가이드 및 커밋 메시지 규칙을 준수했습니다.

## 🖼️ 변경 전/후 스크린샷 (UI 변경 시, 선택)

- 변경된 UI가 있다면 스크린샷을 첨부해 주세요.

## 💬 기타 참고 사항

- 리뷰어가 참고하면 좋을 추가 정보나 특이사항을 적어 주세요.
