### PR TITLE
[Feature] 주문 상세 조회에서 구매한 책 정보도 조회해서 응답하게끔 구현하기 

### DIFF
--- a/src/main/java/com/nhnacademy/bookstoreorderapi/order/controller/OrderController.java
+++ b/src/main/java/com/nhnacademy/bookstoreorderapi/order/controller/OrderController.java
@@ -5,6 +5,7 @@ import com.nhnacademy.bookstoreorderapi.order.dto.SuccessResponseDto;
 import com.nhnacademy.bookstoreorderapi.order.dto.request.OrderRequest;
 import com.nhnacademy.bookstoreorderapi.order.dto.request.ReturnRequest;
 import com.nhnacademy.bookstoreorderapi.order.dto.request.StatusChangeRequest;
+import com.nhnacademy.bookstoreorderapi.order.dto.response.OrderDetailResponse;
 import com.nhnacademy.bookstoreorderapi.order.dto.response.OrderResponse;
 import com.nhnacademy.bookstoreorderapi.order.dto.response.OrderSummaryResponse;
 import com.nhnacademy.bookstoreorderapi.order.dto.response.PurchaseVerificationResponse;
@@ -41,8 +42,9 @@ public class OrderController {
 
     // 회원 주문 상세 조회
     @GetMapping("/{orderId}")
-    public ResponseEntity<OrderResponse> getOrder(@RequestHeader("X-USER-ID") String xUserId, @PathVariable String orderId) {
-        return ResponseEntity.ok().body(orderService.findByOrderId(orderId, xUserId));
+    public ResponseEntity<OrderDetailResponse> getOrder(@RequestHeader("X-USER-ID") String xUserId,
+                                                        @PathVariable String orderId) {
+        return ResponseEntity.ok().body(orderService.findByOrderId(xUserId, orderId));
     }
 
     // 주문 상태 변경

--- a/src/main/java/com/nhnacademy/bookstoreorderapi/order/dto/request/OrderRequest.java
+++ b/src/main/java/com/nhnacademy/bookstoreorderapi/order/dto/request/OrderRequest.java
@@ -13,8 +13,8 @@ public record OrderRequest(
         String receiverName,
 
         @NotBlank(message = "받는 사람 전화번호를 입력해주세요")
-        @Pattern(regexp = "^01\\d\\d{8}$",
-                message = "올바른 휴대폰 번호 형식이 아닙니다 (올바른 형식: 01012345678)")
+        @Pattern(regexp = "^01\\d-\\d{4}-\\d{4}$",
+                message = "올바른 휴대폰 번호 형식이 아닙니다 (올바른 형식: 010-1234-5678)")
         String receiverPhoneNumber,
 
         @NotBlank(message = "배송지를 선택해주세요")

--- a/src/main/java/com/nhnacademy/bookstoreorderapi/order/dto/response/OrderDetailResponse.java
+++ b/src/main/java/com/nhnacademy/bookstoreorderapi/order/dto/response/OrderDetailResponse.java
@@ -1,0 +1,76 @@
+package com.nhnacademy.bookstoreorderapi.order.dto.response;
+
+import com.nhnacademy.bookstoreorderapi.order.client.book.dto.BookResponse;
+import com.nhnacademy.bookstoreorderapi.order.domain.entity.Order;
+import com.nhnacademy.bookstoreorderapi.order.domain.entity.OrderItem;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Getter
+@AllArgsConstructor
+public class OrderDetailResponse {
+
+    private LocalDate orderDate;
+    private String orderId;
+    private String status;
+    private Long totalAmount;
+    private List<ItemInfo> itemInfos;
+    private String receiverName;
+    private String receiverPhoneNumber;
+    private String address;
+    private LocalDate requestedDeliveryDate;
+    private Integer deliveryFee;
+
+    @Getter
+    @AllArgsConstructor
+    public static class ItemInfo {
+
+        private String title;
+        private Integer quantity;
+        private Long bookPrice;
+        private String wrappingName;
+        private Integer wrappingPrice;
+    }
+
+    public static OrderDetailResponse of(Order order, List<OrderItem> items, List<BookResponse> books) {
+        Map<Long, BookResponse> bookMap = books.stream()
+                .collect(Collectors.toMap(BookResponse::id, Function.identity()));
+        
+        List<ItemInfo> itemInfos = items.stream()
+                .map(item -> {
+                    BookResponse book = bookMap.get(item.getBookId());
+                    String title = book != null ? book.title() : "Unknown";
+                    
+                    String wrappingName = item.getWrapping() != null ? item.getWrapping().getName() : null;
+                    Integer wrappingPrice = item.getWrapping() != null ? item.getWrapping().getPrice() : null;
+                    
+                    return new ItemInfo(
+                            title,
+                            item.getQuantity(),
+                            (long) item.getUnitPrice(),
+                            wrappingName,
+                            wrappingPrice
+                    );
+                })
+                .toList();
+        
+        return new OrderDetailResponse(
+                order.getOrderDate(),
+                order.getOrderId(),
+                order.getStatus().name(),
+                order.getTotalPrice(),
+                itemInfos,
+                order.getShippingInfo().getReceiverName(),
+                order.getShippingInfo().getReceiverPhoneNumber(),
+                order.getShippingInfo().getAddress(),
+                order.getShippingInfo().getRequestedDeliveryDate(),
+                order.getShippingInfo().getDeliveryFee()
+        );
+    }
+}

--- a/src/main/java/com/nhnacademy/bookstoreorderapi/order/repository/impl/CustomOrderRepositoryImpl.java
+++ b/src/main/java/com/nhnacademy/bookstoreorderapi/order/repository/impl/CustomOrderRepositoryImpl.java
@@ -19,6 +19,8 @@ import org.springframework.stereotype.Repository;
 import java.time.LocalDate;
 import java.util.List;
 
+import static javax.management.Query.and;
+
 @Repository
 @RequiredArgsConstructor
 public class CustomOrderRepositoryImpl implements CustomOrderRepository {
@@ -36,7 +38,8 @@ public class CustomOrderRepositoryImpl implements CustomOrderRepository {
                         order.shippingInfo.receiverName,
                         order.totalPrice))
                 .from(order)
-                .where(order.userNo.eq(userNo))
+                .where(order.userNo.eq(userNo)
+                        .and(order.status.isNotNull()))
                 .orderBy(order.createdAt.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())

--- a/src/main/java/com/nhnacademy/bookstoreorderapi/order/service/OrderService.java
+++ b/src/main/java/com/nhnacademy/bookstoreorderapi/order/service/OrderService.java
@@ -3,6 +3,7 @@ package com.nhnacademy.bookstoreorderapi.order.service;
 import com.nhnacademy.bookstoreorderapi.order.dto.request.OrderRequest;
 import com.nhnacademy.bookstoreorderapi.order.dto.request.ReturnRequest;
 import com.nhnacademy.bookstoreorderapi.order.dto.request.StatusChangeRequest;
+import com.nhnacademy.bookstoreorderapi.order.dto.response.OrderDetailResponse;
 import com.nhnacademy.bookstoreorderapi.order.dto.response.OrderResponse;
 import com.nhnacademy.bookstoreorderapi.order.dto.response.OrderSummaryResponse;
 import com.nhnacademy.bookstoreorderapi.order.dto.response.PurchaseVerificationResponse;
@@ -13,7 +14,7 @@ public interface OrderService {
 
     OrderResponse createOrder(OrderRequest orderRequest, String xUserId);
     Page<OrderSummaryResponse> findAllByUserId(String xUserId, Pageable pageable);
-    OrderResponse findByOrderId(String orderId, String xUserId);
+    OrderDetailResponse findByOrderId(String xUserId, String orderId);
     void cancelOrder(String orderId, String reason);
     OrderResponse changeStatus(String orderId, StatusChangeRequest req, String xUserId);
     int requestReturn(String orderId, ReturnRequest req);

--- a/src/main/java/com/nhnacademy/bookstoreorderapi/order/service/impl/OrderServiceImpl.java
+++ b/src/main/java/com/nhnacademy/bookstoreorderapi/order/service/impl/OrderServiceImpl.java
@@ -15,6 +15,7 @@ import com.nhnacademy.bookstoreorderapi.order.domain.exception.BookNotFoundExcep
 import com.nhnacademy.bookstoreorderapi.order.dto.request.OrderRequest;
 import com.nhnacademy.bookstoreorderapi.order.dto.request.ReturnRequest;
 import com.nhnacademy.bookstoreorderapi.order.dto.request.StatusChangeRequest;
+import com.nhnacademy.bookstoreorderapi.order.dto.response.OrderDetailResponse;
 import com.nhnacademy.bookstoreorderapi.order.dto.response.OrderResponse;
 import com.nhnacademy.bookstoreorderapi.order.dto.response.OrderSummaryResponse;
 import com.nhnacademy.bookstoreorderapi.order.dto.response.PurchaseVerificationResponse;
@@ -108,13 +109,20 @@ public class OrderServiceImpl implements OrderService {
     }
 
     // 회원 주문 상세 조회
+    @Transactional
     @Override
-    public OrderResponse findByOrderId(String orderId, String xUserId) {
-        Long userNo = getUserNo(xUserId);
+    public OrderDetailResponse findByOrderId(String xUserId, String orderId) {
+        Long userNo = xUserIdResolver.resolveUserNo(xUserId);
         Order order = orderRepository.findByOrderIdAndUserNo(orderId, userNo)
                 .orElseThrow(() -> new OrderNotFoundException(orderId));
+        List<OrderItem> orderItems = orderItemRepository.findAllByOrder(order);
 
-        return OrderResponse.from(order);
+        List<Long> bookIds = orderItems.stream()
+                .map(OrderItem::getBookId)
+                .toList();
+        List<BookResponse> books = bookService.getBookOrderResponse(bookIds);
+
+        return OrderDetailResponse.of(order, orderItems, books);
     }
 
     // 주문 취소

--- a/src/test/java/com/nhnacademy/bookstoreorderapi/order/controller/OrderControllerTest.java
+++ b/src/test/java/com/nhnacademy/bookstoreorderapi/order/controller/OrderControllerTest.java
@@ -3,6 +3,7 @@ package com.nhnacademy.bookstoreorderapi.order.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.nhnacademy.bookstoreorderapi.order.dto.request.OrderRequest;
+import com.nhnacademy.bookstoreorderapi.order.dto.response.OrderDetailResponse;
 import com.nhnacademy.bookstoreorderapi.order.dto.response.OrderResponse;
 import com.nhnacademy.bookstoreorderapi.order.dto.response.OrderSummaryResponse;
 import com.nhnacademy.bookstoreorderapi.order.dto.response.PurchaseVerificationResponse;
@@ -44,6 +45,7 @@ class OrderControllerTest {
     private ObjectMapper objectMapper;
     private OrderRequest validOrderRequest;
     private OrderResponse orderResponse;
+    private OrderDetailResponse detailResponse;
 
     @BeforeEach
     void setUp() {
@@ -60,23 +62,36 @@ class OrderControllerTest {
 
         validOrderRequest = new OrderRequest(
                 "홍길동",
-                "01012345678",
-                "[12345] 서울특별시 강남구 테헤란로 123 10층",
+                "010-1234-5678",
+                "00000 서울특별시 강남구 테헤란로 123 10층",
                 LocalDate.now().plusDays(3),
                 items
         );
 
         orderResponse = new OrderResponse(
-                1L, // id
-                "ORDER-20240101-001", // orderId
-                "PENDING", // status
-                LocalDate.now(), // orderDate
-                "홍길동", // receiverName
-                "01012345678", // receiverPhoneNumber
-                "서울특별시 강남구 테헤란로 123", // address
-                LocalDate.now().plusDays(3), // requestedDeliveryDate
-                3000, // deliveryFee
-                55000L // totalAmount
+                1L,
+                "202507-abcabc-123123",
+                "PENDING",
+                LocalDate.now(),
+                "홍길동",
+                "010-1234-5678",
+                "00000 서울특별시 강남구 테헤란로 123",
+                LocalDate.now().plusDays(3),
+                3000,
+                55000L
+        );
+
+        detailResponse = new OrderDetailResponse(
+                LocalDate.now(),
+                "202507-abcabc-123123",
+                "PENDING",
+                55000L,
+                null,
+                "홍길동",
+                "010-1234-5678",
+                "00000 서울특별시 강남구 테헤란로 123",
+                LocalDate.now().plusDays(3),
+                3000
         );
     }
 
@@ -94,10 +109,10 @@ class OrderControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(validOrderRequest)))
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.orderId").value("ORDER-20240101-001"))
+                .andExpect(jsonPath("$.orderId").value("202507-abcabc-123123"))
                 .andExpect(jsonPath("$.receiverName").value("홍길동"))
-                .andExpect(jsonPath("$.receiverPhoneNumber").value("01012345678"))
-                .andExpect(jsonPath("$.address").value("서울특별시 강남구 테헤란로 123"))
+                .andExpect(jsonPath("$.receiverPhoneNumber").value("010-1234-5678"))
+                .andExpect(jsonPath("$.address").value("00000 서울특별시 강남구 테헤란로 123"))
                 .andExpect(jsonPath("$.totalAmount").value(55000))
                 .andExpect(jsonPath("$.deliveryFee").value(3000))
                 .andExpect(jsonPath("$.status").value("PENDING"));
@@ -119,7 +134,7 @@ class OrderControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(validOrderRequest)))
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.orderId").value("ORDER-20240101-001"))
+                .andExpect(jsonPath("$.orderId").value("202507-abcabc-123123"))
                 .andExpect(jsonPath("$.receiverName").value("홍길동"));
 
         verify(orderService).createOrder(any(OrderRequest.class), eq(xUserId));
@@ -164,8 +179,8 @@ class OrderControllerTest {
         // given
         String xUserId = "testUser";
         List<OrderSummaryResponse> orderSummaries = List.of(
-                new OrderSummaryResponse(LocalDate.now(), "ORDER-20240101-001", "홍길동", 10_000L),
-                new OrderSummaryResponse(LocalDate.now().minusDays(1), "ORDER-20240101-002", "김철수", 10_000L)
+                new OrderSummaryResponse(LocalDate.now(), "202507-abcabc-123123", "홍길동", 10_000L),
+                new OrderSummaryResponse(LocalDate.now().minusDays(1), "202507-abcabc-123124", "김철수", 10_000L)
         );
         Page<OrderSummaryResponse> pageResult = new PageImpl<>(orderSummaries, PageRequest.of(0, 20), 10);
         
@@ -179,9 +194,9 @@ class OrderControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content").isArray())
                 .andExpect(jsonPath("$.content.length()").value(2))
-                .andExpect(jsonPath("$.content[0].orderId").value("ORDER-20240101-001"))
+                .andExpect(jsonPath("$.content[0].orderId").value("202507-abcabc-123123"))
                 .andExpect(jsonPath("$.content[0].receiverName").value("홍길동"))
-                .andExpect(jsonPath("$.content[1].orderId").value("ORDER-20240101-002"))
+                .andExpect(jsonPath("$.content[1].orderId").value("202507-abcabc-123124"))
                 .andExpect(jsonPath("$.content[1].receiverName").value("김철수"));
 
         verify(orderService).findAllByUserId(xUserId, PageRequest.of(0, 20));
@@ -223,30 +238,30 @@ class OrderControllerTest {
     void getOrder_success() throws Exception {
         // given
         String xUserId = "testUser";
-        String orderId = "ORDER-20240101-001";
+        String orderId = "202507-abcabc-123123";
         
-        given(orderService.findByOrderId(orderId, xUserId)).willReturn(orderResponse);
+        given(orderService.findByOrderId(xUserId, orderId)).willReturn(detailResponse);
 
         // when & then
         mockMvc.perform(get("/orders/{orderId}", orderId)
                         .header("X-USER-ID", xUserId))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.orderId").value("ORDER-20240101-001"))
+                .andExpect(jsonPath("$.orderId").value("202507-abcabc-123123"))
                 .andExpect(jsonPath("$.receiverName").value("홍길동"))
-                .andExpect(jsonPath("$.receiverPhoneNumber").value("01012345678"))
-                .andExpect(jsonPath("$.address").value("서울특별시 강남구 테헤란로 123"))
+                .andExpect(jsonPath("$.receiverPhoneNumber").value("010-1234-5678"))
+                .andExpect(jsonPath("$.address").value("00000 서울특별시 강남구 테헤란로 123"))
                 .andExpect(jsonPath("$.totalAmount").value(55000))
                 .andExpect(jsonPath("$.deliveryFee").value(3000))
                 .andExpect(jsonPath("$.status").value("PENDING"));
 
-        verify(orderService).findByOrderId(orderId, xUserId);
+        verify(orderService).findByOrderId(xUserId, orderId);
     }
 
     @Test
     @DisplayName("회원 주문 상세 조회 시 X-USER-ID 헤더가 없으면 400 에러가 발생한다")
     void getOrder_missingXUserIdHeader_badRequest() throws Exception {
         // given
-        String orderId = "ORDER-20240101-001";
+        String orderId = "202507-abcabc-123123";
 
         // when & then
         mockMvc.perform(get("/orders/{orderId}", orderId))

--- a/src/test/java/com/nhnacademy/bookstoreorderapi/order/service/impl/OrderServiceImplTest.java
+++ b/src/test/java/com/nhnacademy/bookstoreorderapi/order/service/impl/OrderServiceImplTest.java
@@ -7,10 +7,13 @@ import com.nhnacademy.bookstoreorderapi.order.client.book.service.BookService;
 import com.nhnacademy.bookstoreorderapi.order.client.user.dto.UserResponse;
 import com.nhnacademy.bookstoreorderapi.order.client.user.service.UserService;
 import com.nhnacademy.bookstoreorderapi.order.common.exception.MissingRequiredParameterException;
+import com.nhnacademy.bookstoreorderapi.order.common.resolver.XUserIdResolver;
 import com.nhnacademy.bookstoreorderapi.order.domain.entity.Order;
+import com.nhnacademy.bookstoreorderapi.order.domain.entity.OrderStatus;
 import com.nhnacademy.bookstoreorderapi.order.domain.entity.Wrapping;
 import com.nhnacademy.bookstoreorderapi.order.domain.exception.BookNotFoundException;
 import com.nhnacademy.bookstoreorderapi.order.dto.request.OrderRequest;
+import com.nhnacademy.bookstoreorderapi.order.dto.response.OrderDetailResponse;
 import com.nhnacademy.bookstoreorderapi.order.dto.response.OrderResponse;
 import com.nhnacademy.bookstoreorderapi.order.dto.response.OrderSummaryResponse;
 import com.nhnacademy.bookstoreorderapi.order.dto.response.PurchaseVerificationResponse;
@@ -53,6 +56,8 @@ class OrderServiceImplTest {
     OrderValidationService orderValidationService;
     @Mock
     CustomOrderRepository customOrderRepository;
+    @Mock
+    XUserIdResolver xUserIdResolver;
 
     @InjectMocks
     private OrderServiceImpl orderService;
@@ -71,7 +76,7 @@ class OrderServiceImplTest {
 
         validOrderRequest = new OrderRequest(
                 "홍길동",
-                "01012345678",
+                "010-1234-5678",
                 "12345 서울특별시 강남구 테헤란로 123 10층",
                 LocalDate.now().plusDays(3),
                 items
@@ -257,20 +262,21 @@ class OrderServiceImplTest {
     void findByOrderId_success() {
         // given
         String xUserId = "testUser";
-        String orderId = "ORDER-20240101-001";
+        String orderId = "202507-abcabc-123123";
         Long userNo = 1L;
         
         Order mockOrder = Order.of(validOrderRequest, userNo);
+        mockOrder.setStatus(OrderStatus.PENDING);
         
-        given(userService.getUserInfo(xUserId)).willReturn(userResponse);
+        given(xUserIdResolver.resolveUserNo(xUserId)).willReturn(userNo);
         given(orderRepository.findByOrderIdAndUserNo(orderId, userNo)).willReturn(Optional.of(mockOrder));
         
         // when
-        OrderResponse result = orderService.findByOrderId(orderId, xUserId);
+        OrderDetailResponse result = orderService.findByOrderId(xUserId, orderId);
         
         // then
         assertThat(result).isNotNull();
-        verify(userService).getUserInfo(xUserId);
+        verify(xUserIdResolver).resolveUserNo(xUserId);
         verify(orderRepository).findByOrderIdAndUserNo(orderId, userNo);
     }
 
@@ -279,19 +285,16 @@ class OrderServiceImplTest {
     void findByOrderId_orderNotFound_throwsException() {
         // given
         String xUserId = "testUser";
-        String orderId = "ORDER-20240101-001";
-        Long userNo = 1L;
-        
-        given(userService.getUserInfo(xUserId)).willReturn(userResponse);
+        String orderId = "202507-abcabc-123123";
+        Long userNo = -1L;
+
+        given(xUserIdResolver.resolveUserNo(xUserId)).willReturn(userNo);
         given(orderRepository.findByOrderIdAndUserNo(orderId, userNo)).willReturn(Optional.empty());
         
         // when & then
-        assertThatThrownBy(() -> orderService.findByOrderId(orderId, xUserId))
+        assertThatThrownBy(() -> orderService.findByOrderId(xUserId, orderId))
                 .isInstanceOf(OrderNotFoundException.class)
                 .hasMessage("주문을 찾을 수 없습니다: orderId=" + orderId);
-        
-        verify(userService).getUserInfo(xUserId);
-        verify(orderRepository).findByOrderIdAndUserNo(orderId, userNo);
     }
 
     @Test
@@ -299,19 +302,16 @@ class OrderServiceImplTest {
     void findByOrderId_differentUser_throwsException() {
         // given
         String xUserId = "testUser";
-        String orderId = "ORDER-20240101-001";
-        Long userNo = 1L;
-        
-        given(userService.getUserInfo(xUserId)).willReturn(userResponse);
+        String orderId = "202507-abcabc-123123";
+        Long userNo = -1L;
+
+        given(xUserIdResolver.resolveUserNo(xUserId)).willReturn(userNo);
         given(orderRepository.findByOrderIdAndUserNo(orderId, userNo)).willReturn(Optional.empty());
         
         // when & then
-        assertThatThrownBy(() -> orderService.findByOrderId(orderId, xUserId))
+        assertThatThrownBy(() -> orderService.findByOrderId(xUserId, orderId))
                 .isInstanceOf(OrderNotFoundException.class)
                 .hasMessage("주문을 찾을 수 없습니다: orderId=" + orderId);
-        
-        verify(userService).getUserInfo(xUserId);
-        verify(orderRepository).findByOrderIdAndUserNo(orderId, userNo);
     }
 
     @Test
@@ -357,19 +357,21 @@ class OrderServiceImplTest {
     void findByOrderId_withNullXUserId_success() {
         // given
         String xUserId = null;
-        String orderId = "ORDER-20240101-001";
+        String orderId = "202507-abcabc-123123";
         
         Order mockOrder = Order.of(validOrderRequest, null);
+        mockOrder.setStatus(OrderStatus.PENDING);
         
-        given(orderRepository.findByOrderIdAndUserNo(orderId, null))
+        given(xUserIdResolver.resolveUserNo(xUserId)).willReturn(0L);
+        given(orderRepository.findByOrderIdAndUserNo(orderId, 0L))
                 .willReturn(Optional.of(mockOrder));
         
         // when
-        OrderResponse result = orderService.findByOrderId(orderId, xUserId);
+        OrderDetailResponse result = orderService.findByOrderId(xUserId, orderId);
         
         // then
         assertThat(result).isNotNull();
-        verify(orderRepository).findByOrderIdAndUserNo(orderId, null);
+        verify(orderRepository).findByOrderIdAndUserNo(orderId, 0L);
         verify(userService, never()).getUserInfo(anyString());
     }
 
@@ -378,19 +380,21 @@ class OrderServiceImplTest {
     void findByOrderId_withBlankXUserId_success() {
         // given
         String xUserId = "";
-        String orderId = "ORDER-20240101-001";
+        String orderId = "202507-abcabc-123123";
         
         Order mockOrder = Order.of(validOrderRequest, null);
+        mockOrder.setStatus(OrderStatus.PENDING);
         
-        given(orderRepository.findByOrderIdAndUserNo(orderId, null))
+        given(xUserIdResolver.resolveUserNo(xUserId)).willReturn(0L);
+        given(orderRepository.findByOrderIdAndUserNo(orderId, 0L))
                 .willReturn(Optional.of(mockOrder));
         
         // when
-        OrderResponse result = orderService.findByOrderId(orderId, xUserId);
+        OrderDetailResponse result = orderService.findByOrderId(xUserId, orderId);
         
         // then
         assertThat(result).isNotNull();
-        verify(orderRepository).findByOrderIdAndUserNo(orderId, null);
+        verify(orderRepository).findByOrderIdAndUserNo(orderId, 0L);
         verify(userService, never()).getUserInfo(anyString());
     }
 


### PR DESCRIPTION
Closes #110

<!-- .github/pull_request_template.md -->

## 📝 PR 개요

- 주문 상세조회 페이지에서 주문한 책 정보도 볼 수 있게 기능 구현 

## 🔗 관련 이슈

- #110 

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작합니다.
- [ ] 새로운/수정된 기능에 대한 테스트를 추가했습니다.
- [ ] 문서(README 등)를 최신 상태로 반영했습니다.
- [x] 코드 스타일 가이드 및 커밋 메시지 규칙을 준수했습니다.

## 🖼️ 변경 전/후 스크린샷 (UI 변경 시, 선택)

- 변경된 UI가 있다면 스크린샷을 첨부해 주세요.

## 💬 기타 참고 사항

- 리뷰어가 참고하면 좋을 추가 정보나 특이사항을 적어 주세요.
