### PR TITLE
[Feature] 리뷰 작성 가능한 '주문 상태' 변경하기 

### DIFF
--- a/src/main/java/com/nhnacademy/bookstoreorderapi/order/dto/response/OrderStatusResult.java
+++ b/src/main/java/com/nhnacademy/bookstoreorderapi/order/dto/response/OrderStatusResult.java
@@ -1,7 +1,18 @@
 package com.nhnacademy.bookstoreorderapi.order.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.nhnacademy.bookstoreorderapi.payment.dto.Response.PaymentResDto;
 
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.PROPERTY,
+    property = "type"
+)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = OrderStatusResult.CancelResult.class, name = "cancel"),
+    @JsonSubTypes.Type(value = OrderStatusResult.ReturnResult.class, name = "return")
+})
 public sealed interface OrderStatusResult 
     permits OrderStatusResult.CancelResult, OrderStatusResult.ReturnResult {
     

--- a/src/main/java/com/nhnacademy/bookstoreorderapi/order/repository/impl/CustomOrderRepositoryImpl.java
+++ b/src/main/java/com/nhnacademy/bookstoreorderapi/order/repository/impl/CustomOrderRepositoryImpl.java
@@ -109,7 +109,7 @@ public class CustomOrderRepositoryImpl implements CustomOrderRepository {
                 .join(orderItem.order, order)
                 .where(order.userNo.eq(userNo)
                         .and(orderItem.bookId.eq(bookId))
-                        .and(order.status.in(OrderStatus.PENDING_PAY, OrderStatus.SHIPPING, OrderStatus.COMPLETED)))
+                        .and(order.status.eq(OrderStatus.COMPLETED)))
                 .fetchFirst() != null;
     }
 

--- a/src/test/java/com/nhnacademy/bookstoreorderapi/order/repository/impl/CustomOrderRepositoryImplTest.java
+++ b/src/test/java/com/nhnacademy/bookstoreorderapi/order/repository/impl/CustomOrderRepositoryImplTest.java
@@ -232,6 +232,30 @@ class CustomOrderRepositoryImplTest {
     }
 
     @Test
+    @DisplayName("구매 검증 테스트 - 'PENDING_PAY'인 경우는 리뷰를 쓰지 못하게 해야해서 구매하지 않은 것으로 본다")
+    void shouldVerifyPurchase_pending() {
+        // given
+        Long userNo = 1L;
+        Long bookId = 100L;
+
+        Order order = new Order(userNo);
+        order.setStatus(OrderStatus.PENDING_PAY);
+        Order savedOrder = orderRepository.save(order);
+
+        OrderItem orderItem = new OrderItem(bookId, "책제목", 10_000, 1, savedOrder);
+        entityManager.persist(orderItem);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        boolean result = orderRepository.findByUserNoAndBookId(userNo, bookId);
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @Test
     @DisplayName("존재하지 않는 주문번호로 주문ID 조회 테스트")
     void shouldReturnNullForNonExistentOrderNumber() {
         // given


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📝 PR 개요

- 리뷰 작성 가능한 '주문 상태'를 'COMPLETED'로 변경 
- OrderStatusResult의 구현체를 잘 구분해서 역직렬화할 수 있게 @JsonTypeInfo, @JsonSubTypes를 써서 해결함. 

## 🔗 관련 이슈

- #144 

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작합니다.
- [x] 새로운/수정된 기능에 대한 테스트를 추가했습니다.
- [ ] 문서(README 등)를 최신 상태로 반영했습니다.
- [x] 코드 스타일 가이드 및 커밋 메시지 규칙을 준수했습니다.

## 🖼️ 변경 전/후 스크린샷 (UI 변경 시, 선택)

- 변경된 UI가 있다면 스크린샷을 첨부해 주세요.

## 💬 기타 참고 사항

- 리뷰어가 참고하면 좋을 추가 정보나 특이사항을 적어 주세요.
